### PR TITLE
Fix operation on Supplier Inventory Sync job

### DIFF
--- a/LinkGreenODBCUtility/Services/Jobs/SupplierInventorySyncJob.cs
+++ b/LinkGreenODBCUtility/Services/Jobs/SupplierInventorySyncJob.cs
@@ -18,7 +18,7 @@ namespace LinkGreenODBCUtility.Services.Jobs
             Tasks.StartTask(jobName);
 
             var supplierInventories = new SupplierInventories();
-            var result = supplierInventories.PushMatchedSkus();
+            var result = supplierInventories.Publish();
             if (result)
             {
                 Logger.Instance.Info("Matched Supplier Inventory Synced.");


### PR DESCRIPTION
For the scheduled task, call Publish instead of PushMatchedSkus